### PR TITLE
ACE: correct behavior of 'Exodus Write Interval' in 'master' file for sequentially-coupled themo-mech problems

### DIFF
--- a/src/LCM/solvers/ACE_ThermoMechanical.cpp
+++ b/src/LCM/solvers/ACE_ThermoMechanical.cpp
@@ -23,6 +23,7 @@ getName(std::string const& method)
 
 void deleteExoFile(const std::string file_name, Teuchos::RCP<Teuchos::Comm<int> const> comm) 
 {
+  Teuchos::RCP<Teuchos::FancyOStream> fos_ = Teuchos::VerboseObjectBase::getDefaultOStream(); 
   const int num_ranks = comm->getSize(); 
   const int this_rank = comm->getRank();  
   std::string full_file_name = file_name + "." + std::to_string(num_ranks) + "." + std::to_string(this_rank); 
@@ -30,10 +31,10 @@ void deleteExoFile(const std::string file_name, Teuchos::RCP<Teuchos::Comm<int> 
   strcpy(cstr, full_file_name.c_str()); 
   int const file_removed = remove(cstr); 
   if (file_removed == 0) {
-    std::cout  << "Exodus file " << full_file_name << " deleted successfully!\n";
+    *fos_  << "Exodus files based off of " << file_name << " deleted successfully!\n";
   }
   else {
-    std::cout << "Unable to delete Exodus file " << full_file_name << "!\n";
+    *fos_ << "Unable to delete Exodus files based off of " << file_name << "!\n";
   }
 }
 }  // namespace
@@ -472,7 +473,10 @@ ACEThermoMechanical::createThermalSolverAppDiscME(int const file_index, double c
   model_evaluators_[subdomain]   = solver_factories_[subdomain]->returnModel();
   curr_x_[subdomain]             = Teuchos::null;
   prev_thermal_exo_outfile_name_ = filename;
-  deleteExoFile(prev_mechanical_exo_outfile_name_, comm_); 
+  //Delete previously-written Exodus files to not have inundation of output files
+  if (((file_index-1) % output_interval_) != 0) {
+    deleteExoFile(prev_mechanical_exo_outfile_name_, comm_); 
+  }
 }
 
 void
@@ -541,7 +545,10 @@ ACEThermoMechanical::createMechanicalSolverAppDiscME(int const file_index, doubl
   model_evaluators_[subdomain]      = solver_factories_[subdomain]->returnModel();
   curr_x_[subdomain]                = Teuchos::null;
   prev_mechanical_exo_outfile_name_ = filename;
-  //deleteExoFile(prev_thermal_exo_outfile_name_, comm_); 
+  //Delete previously-written Exodus files to not have inundation of output files
+  if ((file_index % output_interval_) != 0) {
+    deleteExoFile(prev_thermal_exo_outfile_name_, comm_); 
+  }
 }
 
 bool

--- a/src/LCM/solvers/ACE_ThermoMechanical.cpp
+++ b/src/LCM/solvers/ACE_ThermoMechanical.cpp
@@ -20,6 +20,22 @@ getName(std::string const& method)
   if (method.size() < 3) return method;
   return method.substr(0, method.size() - 3);
 }
+
+void deleteExoFile(const std::string file_name, Teuchos::RCP<Teuchos::Comm<int> const> comm) 
+{
+  const int num_ranks = comm->getSize(); 
+  const int this_rank = comm->getRank();  
+  std::string full_file_name = file_name + "." + std::to_string(num_ranks) + "." + std::to_string(this_rank); 
+  char cstr[full_file_name.size()+1]; 
+  strcpy(cstr, full_file_name.c_str()); 
+  int const file_removed = remove(cstr); 
+  if (file_removed == 0) {
+    std::cout  << "Exodus file " << full_file_name << " deleted successfully!\n";
+  }
+  else {
+    std::cout << "Unable to delete Exodus file " << full_file_name << "!\n";
+  }
+}
 }  // namespace
 
 namespace LCM {
@@ -411,7 +427,6 @@ ACEThermoMechanical::createThermalSolverAppDiscME(int const file_index, double c
   renameExodusFile(file_index, filename);
   *fos_ << "Renaming output file to - " << filename << '\n';
   disc_params.set<std::string>("Exodus Output File Name", filename);
-
   disc_params.set<std::string>("Exodus Solution Name", "temperature");
   disc_params.set<std::string>("Exodus SolutionDot Name", "temperature_dot");
   disc_params.set<bool>("Output DTK Field to Exodus", false);
@@ -457,6 +472,7 @@ ACEThermoMechanical::createThermalSolverAppDiscME(int const file_index, double c
   model_evaluators_[subdomain]   = solver_factories_[subdomain]->returnModel();
   curr_x_[subdomain]             = Teuchos::null;
   prev_thermal_exo_outfile_name_ = filename;
+  deleteExoFile(prev_mechanical_exo_outfile_name_, comm_); 
 }
 
 void
@@ -525,6 +541,7 @@ ACEThermoMechanical::createMechanicalSolverAppDiscME(int const file_index, doubl
   model_evaluators_[subdomain]      = solver_factories_[subdomain]->returnModel();
   curr_x_[subdomain]                = Teuchos::null;
   prev_mechanical_exo_outfile_name_ = filename;
+  //deleteExoFile(prev_thermal_exo_outfile_name_, comm_); 
 }
 
 bool

--- a/src/LCM/solvers/ACE_ThermoMechanical.hpp
+++ b/src/LCM/solvers/ACE_ThermoMechanical.hpp
@@ -168,6 +168,9 @@ class ACEThermoMechanical : public Thyra::ResponseOnlyModelEvaluatorBase<ST>
   void
   doDynamicInitialOutput(ST const time, int const subdomain, int const stop) const;
 
+  void 
+  renamePrevWrittenExoFiles(const int subdomain, const int file_index) const; 
+
   void
   setExplicitUpdateInitialGuessForCoupling(ST const current_time, ST const time_step) const;
 

--- a/tests/LCM/ACE/CuboidSequentialThermoMechanical3D/CMakeLists.txt
+++ b/tests/LCM/ACE/CuboidSequentialThermoMechanical3D/CMakeLists.txt
@@ -76,7 +76,7 @@ if(NOT ALBANY_PARALLEL_ONLY)
   # Name the test with the directory name
   get_filename_component(testName ${CMAKE_CURRENT_SOURCE_DIR} NAME)
   # Add the tests
-  set(OUTFILE "thermal.e-s.119")
+  set(OUTFILE "thermal.e-s.17")
   set(REF_FILE "${CMAKE_CURRENT_BINARY_DIR}/../CuboidThermoMechanical3D/grid.e")
   add_test(
     NAME ACE_${testName}
@@ -89,8 +89,8 @@ if(NOT ALBANY_PARALLEL_ONLY)
   set_tests_properties(ACE_${testName}
                        PROPERTIES DEPENDS CuboidThermoMechanical3D_ThermalOnly)
   
-  set(OUTFILE "thermal-vardt.e-s.40")
-  set(REF_FILE "thermal.e-s.119")
+  set(OUTFILE "thermal-vardt.e-s.8")
+  set(REF_FILE "thermal.e-s.17")
   add_test(
     NAME ACE_${testName}_vardt
     COMMAND

--- a/tests/LCM/ACE/CuboidSequentialThermoMechanical3D/coupled.yaml
+++ b/tests/LCM/ACE/CuboidSequentialThermoMechanical3D/coupled.yaml
@@ -9,7 +9,7 @@ LCM:
     Reduction Factor: 5.00000000000000000e-01
     #Amplification Factor: 1.50000000000000000e+00
     Amplification Factor: 1.00000000000000000e+00
-    Exodus Write Interval: 1
+    Exodus Write Interval: 7
   # MODEL DECLARATION, Look in the Problem directory
   Problem:
     # Transient or Steady (Quasi-Static) or Continuation (load steps)

--- a/tests/LCM/ACE/CuboidThermoMechanical3D/coupled.yaml
+++ b/tests/LCM/ACE/CuboidThermoMechanical3D/coupled.yaml
@@ -1,0 +1,19 @@
+LCM:
+  Alternating System:
+    Model Input Files: [thermal.yaml, mechanical.yaml]
+    Initial Time: 0.00000000000000000e+00
+    #Final Time: 17280000.0 # 200 days in seconds
+    Final Time: 864000.0 # 10 days in seconds
+    Initial Time Step: 7200.0 # 2 hr in seconds
+    Maximum Steps: 10000
+    Reduction Factor: 5.00000000000000000e-01
+    #Amplification Factor: 1.50000000000000000e+00
+    Amplification Factor: 1.00000000000000000e+00
+    Exodus Write Interval: 7
+  # MODEL DECLARATION, Look in the Problem directory
+  Problem:
+    # Transient or Steady (Quasi-Static) or Continuation (load steps)
+    Solution Method: ACE Sequential Thermo-Mechanical
+    # Have Phalanx output a graph of the used evaluators
+    Phalanx Graph Visualization Detail: 0
+...

--- a/tests/LCM/ACE/CuboidThermoMechanical3D/coupled_vardt.yaml
+++ b/tests/LCM/ACE/CuboidThermoMechanical3D/coupled_vardt.yaml
@@ -1,0 +1,20 @@
+LCM:
+  Alternating System:
+    Model Input Files: [thermal_vardt.yaml, mechanical_vardt.yaml]
+    Initial Time: 0.00000000000000000e+00
+    #Final Time: 17280000.0 # 200 days in seconds
+    Final Time: 864000.0 # 10 days in seconds
+    Initial Time Step: 7200.0 # 2 hr in seconds
+    Maximum Time Step: 21600.0 
+    Minimum Time Step: 600.0 
+    Maximum Steps: 10000
+    Reduction Factor: 5.00000000000000000e-01
+    Amplification Factor: 2.0000000000000000e+00
+    Exodus Write Interval: 5
+  # MODEL DECLARATION, Look in the Problem directory
+  Problem:
+    # Transient or Steady (Quasi-Static) or Continuation (load steps)
+    Solution Method: ACE Sequential Thermo-Mechanical
+    # Have Phalanx output a graph of the used evaluators
+    Phalanx Graph Visualization Detail: 0
+...


### PR DESCRIPTION
Prevents proliferation of Exodus output files by deleting the previously-written Exodus files that don't match 'Exodus Write Interval', and renaming the remaining files to make them sequentially numbered.